### PR TITLE
Updates based on first round of claims

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .vs/RABET-V-Pilot/v16/.suo
 *.sqlite
 WorkingModel/.DS_Store
+build/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@
 *.sqlite
 WorkingModel/.DS_Store
 build/
+.idea/workspace.xml
+.idea/vcs.xml
+.idea/RABET-V-Pilot.iml
+.idea/modules.xml
+.idea/misc.xml

--- a/docs/source/Activities/Security_Claims_Validation.md
+++ b/docs/source/Activities/Security_Claims_Validation.md
@@ -9,6 +9,7 @@ For each requirement, the provider must include:
 1.  Whether the requirement is:
 
     1. Met,
+    1. Met, User Dependent,
     1. Partially Met,
     1. Not Met, or
     1. Not Applicable

--- a/docs/source/Security_Services_Capability_Maturity_Index/Authentication_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/Authentication_Requirements.md
@@ -84,13 +84,6 @@ Method: Copy
 
 >Reference: CIS Security Best Practices for Non-Voting Election Technology A1.2.2
 
-### Ensure the Use of Dedicated Vendor Administrative Accounts
-
-Ensure that all users with administrative account access use a dedicated or secondary account for elevated activities. This account should only be used for administrative activities and day-to-day activities.
-
->Administrator account on election technology endpoints should not be used for anything but administrator level activities and only when necessary.
-
->Reference: CIS Security Best Practices for Non-Voting Election Technology 2.4.3
 
 ### Black list commonly used passwords
 

--- a/docs/source/Security_Services_Capability_Maturity_Index/Authentication_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/Authentication_Requirements.md
@@ -188,9 +188,9 @@ Method: Copy
 
 >Reference: CIS Security Best Practices for Non-Voting Election Technology 5.1.3
 
-### Provide the ability for customer admins to revoke access 
+### Provide the ability for customer admins to revoke access
 
-Establish and follow an automated process for revoking system access by disabling accounts immediately upon termination or change of responsibilities of an employee or contractor. Disabling those accounts, instead of deleting accounts, allows preservation of audit trails.
+Establish and follow an automated process for revoking system access by disabling accounts immediately upon termination or change of responsibilities of an employee or contractor.
 
 >Employee new hire, termination, promotion, and demotion checklists should include the steps to setting user permissions commensurate with the employee's job responsibilities, or lack thereof. This should apply to employees and contractors.
 

--- a/docs/source/Security_Services_Capability_Maturity_Index/Boundary_Protection_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/Boundary_Protection_Requirements.md
@@ -225,10 +225,10 @@ Method: Copy
 
 >Reference: CIS Security Best Practices for Non-Voting Election Technology 4.1.7
 
-### Disable Workstation-to-Workstation Communication
+### Limit Workstation-to-Workstation Communication
 
-Using technologies such as private VLANs or micro-segmentation, disable all workstation-to-workstation communication to limit an attacker's ability to move laterally and compromise neighboring systems. 
->Whenever possible, workstations should be limited to talking only to servers.
+When not in use, limit workstation-to-workstation communication using technologies such as private VLANs or micro-segmentation. 
+>Whenever possible, workstations should be limited to talking only to servers thereby limiting lateral movement between workstations.
 
 Applies to: On-prem components
 

--- a/docs/source/Security_Services_Capability_Maturity_Index/Boundary_Protection_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/Boundary_Protection_Requirements.md
@@ -109,7 +109,7 @@ Method: Copy
 ### Disable Wireless Peripheral Access to Devices
 
 Disable wireless peripheral access of devices (such as Bluetooth and NFC), unless such access is required for a business purpose.
->Printers and other peripherals often have Bluetooth capabilities that should be disabled unless absolutely necessary.
+>Printers and other peripherals often have Bluetooth capabilities.
 
 Applies to: On-prem components
 

--- a/docs/source/Security_Services_Capability_Maturity_Index/Data_Confidentiality_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/Data_Confidentiality_Requirements.md
@@ -37,17 +37,6 @@ Method: Copy
 
 >Reference: CIS Security Best Practices for Non-Voting Election Technology 4.1.1
 
-### Remove or Isolate Sensitive Data or Systems Not Regularly Accessed by the Organization
-
-Remove sensitive data or systems not regularly accessed by the organization from the network. These systems should only be used as stand-alone systems (disconnected from the network) by the business unit needing to occasionally use the system or completely virtualized and powered off until needed.
-
->Disconnect systems that store or process election data that do not absolutely have to be online. Do not leave USB devices with sensitive information plugged into machines when they are not in use.
-
-Applies to: All components
-
-Method: Copy
-
->Reference: CIS Security Best Practices for Non-Voting Election Technology 4.1.2
 
 ### Follow Secure Configuration Guidance for Cloud Storage
 
@@ -232,6 +221,18 @@ Applies to: Hosted components
 Method: Copy
 
 >Reference: CIS Security Best Practices for Non-Voting Election Technology 4.3.4
+
+### Remove or Isolate Sensitive Data or Systems Not Regularly Accessed by the Organization
+
+Remove sensitive data or systems not regularly accessed by the organization from the network. 
+
+>These systems should only be used as stand-alone systems (disconnected from the network) by the business unit needing to occasionally use the system or completely virtualized and powered off until needed. In addition, disconnect systems that store or process election data that do not absolutely have to be online. Do not leave USB devices with sensitive information plugged into machines when they are not in use. 
+
+Applies to: All components
+
+Method: Copy
+
+>Reference: CIS Security Best Practices for Non-Voting Election Technology 4.1.2
 
 ### Don't Use Unvalidated Forwards or Redirects
 

--- a/docs/source/Security_Services_Capability_Maturity_Index/Data_Integrity_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/Data_Integrity_Requirements.md
@@ -34,9 +34,9 @@ Method: Copy
 
 ## Maturity Level 2
 
-### Verify Data on Backup Media
+### Backup data should be restorable
 
-Test data integrity on backup media on a regular basis by performing a data restoration process to ensure that the backup is properly working.
+Verify backup data is restorable by performing a data restoration.
 >This is important to do once per election or more frequently for some systems.
 
 Applies to: Hosted components

--- a/docs/source/Security_Services_Capability_Maturity_Index/Injection_Prevention_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/Injection_Prevention_Requirements.md
@@ -6,6 +6,8 @@ In these requirements, *interpreted* is defined as: Input that may be treated as
 
 ### Use Secure HTTP Response Headers
 
+[Public key pins is deprecated. Unclear if replacement is well supported]
+
 To protect against cross-site scripting (XSS) and man-in-the-middle (MITM) attacks, use the Content Security Policy (CSP) and Public-Key-Pins headers.
 
 Applies to: Web components

--- a/docs/source/Security_Services_Capability_Maturity_Index/Logging_Alerting_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/Logging_Alerting_Requirements.md
@@ -38,7 +38,7 @@ Method: Copy
 
 ### Log All Privilege Changes
 
-Log all activities or occasions where the user's privilege level changes.
+Log all activities or occasions where the user's privilege level escalates.
 
 Applies to: All
 

--- a/docs/source/Security_Services_Capability_Maturity_Index/System_Integrity_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/System_Integrity_Requirements.md
@@ -4,8 +4,7 @@
 
 ### Install the Latest Stable Version of Any Security-Related Updates on All Network Devices
 
-
-Install the latest stable version of any security-related updates on all network devices. Latest refers to all updates which were available prior to the internal product testing of the product. 
+Install the latest stable version of any security-related updates on all network devices. Latest refers to all updates which were available prior to the internal product testing of the product.
 
 > Ensure that you are monitoring for updates and applying them as you are able. This may require a plan to make updates prior to sensitive election dates.
 
@@ -41,9 +40,9 @@ Method: Derived
 
 > Reference: CIS Security Best Practices for Non-Voting Election Technology 2.5.3
 
-### Use USB Port Protectors on Unused Ports
+### Use Port Protectors on Unused Ports
 
-Cover all unused USB ports on endpoint devices with locks or tamper-evident port protectors to ensure unauthorized USB devices are not inserted into the device. This must be done prior to delivery to the customer.
+Cover all unused communication ports (e.g. USB, Thunderbolt, HDMI, etc.) on endpoint devices with locks or tamper-evident port protectors to ensure unauthorized devices are not inserted into the device. This must be done prior to delivery to the customer.
 
 Applies to: Provider supplied hardware
 
@@ -53,11 +52,9 @@ Method: Derived
 
 ### Backup and Failover capabilities
 
-Application and data storage components have fail over options in the event of a service degradation for primary component. 
-
+Application and data storage components have fail over options in the event of a service degradation for primary component.
 
 ## Maturity Level 2
-
 
 ### Perform Complete System Backups
 
@@ -85,7 +82,7 @@ Method: Copy
 
 ### Deploy Operating System Patchs
 
-Operating systems are running the latest security updates provided by the software vendor. Latest refers to all updates which were available prior to the internal product testing of the product. 
+Operating systems are running the latest security updates provided by the software vendor. Latest refers to all updates which were available prior to the internal product testing of the product.
 
 > Ensure all systems are updated until it is no longer appropriate to make changes to a system before an election. Beyond this point, patches should be reviewed by security personnel and a decision should be made on whether the operational risk of patching it greater than the security risk posed by the vulnerability.
 
@@ -95,9 +92,9 @@ Method: Copy
 
 > Reference: CIS Security Best Practices for Non-Voting Election Technology 2.2.4
 
-### Deploy Software Patchs
+### Deploy Software Patches
 
-Third-party software on all systems is running the latest security updates provided by the software vendor. Latest refers to all updates which were available prior to the internal product testing of the product. 
+Third-party software on all systems is running the latest security updates provided by the software vendor. Latest refers to all updates which were available prior to the internal product testing of the product.
 
 > Ensure that software is patched until it is no longer appropriate to make changes to software prior to an election. After this date, manually review patches to determine if the operational risk of patching is greater than the security risk of the vulnerability the patch fixes.
 
@@ -155,7 +152,6 @@ Method: Copy
 
 > Reference: CIS Security Best Practices for Non-Voting Election Technology 3.2.16
 
-
 ## Maturity Level 3
 
 ### Establish DDoS Mitigation Services With a Third-Party DDoS Mitigation Provider
@@ -171,8 +167,8 @@ Method: Copy
 > Reference: CIS Security Best Practices for Non-Voting Election Technology 1.5.6
 
 ### Implement Automated Configuration Monitoring Systems
-
-Utilize a Security Content Automation Protocol (SCAP) compliant configuration monitoring system to verify all security configuration elements, catalog approved exceptions, and alert when unauthorized changes occur.
+[Revisit]
+Utilize a Security Content Automation Protocol (SCAP) compliant or equivelent configuration monitoring system to verify all security configuration elements, catalog approved exceptions, and alert when unauthorized changes occur.
 
 > This prevents accidental misconfiguration and allows election technology providers the ability to prove the component has been properly and securely configured.
 
@@ -204,13 +200,13 @@ Method: Copy
 
 ### Disable Access to USB Devices Where Possible
 
-Disable the use of USB devices on a system to completely remove the risk of removable USB media based attacks.
+Disable the use of USB devices (including Thunderbolt) on a system to completely remove the risk of removable USB media based attacks.
 
 > This may not be feasible for all components. It should be feasible for servers and other devices which do not use USB connected devices.
 
 Applies to: Vendor provided hardware
 
-Method: Copy
+Method: Derived
 
 > Reference: CIS Security Best Practices for Non-Voting Election Technology 2.5.7
 

--- a/docs/source/Security_Services_Capability_Maturity_Index/User_Session_Management_Requirements.md
+++ b/docs/source/Security_Services_Capability_Maturity_Index/User_Session_Management_Requirements.md
@@ -88,18 +88,6 @@ Method: Derived
 
 > Reference: CIS Security Best Practices for Non-Voting Election Technology A1.5.10
 
-### Implement an Absolute Session Timeout
-
-During non-time-sensitive periods, users should be logged out after an extensive amount of time (e.g., 4-8 hours) has passed since they logged in, regardless of activity. This helps mitigate the risk of an attacker using a hijacked session.
-
-> Does not apply to interfaces that are used on Election Day and require instantaneous access.
-
-Applies to: Web components
-
-Method: Copy
-
-> Reference: CIS Security Best Practices for Non-Voting Election Technology A1.5.8
-
 ## Maturity Level 3
 
 ### Destroy Sessions at Any Sign of Tampering


### PR DESCRIPTION
Changes:

- Add `build/` to `.gitignore`
- Strike 1.2.2
- Revise aside language in 1.3.5
- Soften language in 3.1.10
- Rework 3.3.4
- Move 4.1.4 to level two, as 4.2.7
- Rewrite 5.2.1
- Clarify aside in 7.1.4
- Strike *Implement an Absolute Session Timeout* (10.1.x)
- Add claim response of *Met, User Dependent*
- Change requirement title of 9.1.4 to remove reference to USB, and add examples
- Change requirement text of 9.3.2 to allow SCAP equivalent (TBD) tools
- Change requirement text of 9.3.5 to include Thunderbolt under USB

(note some changes will require corresponding changes to the Security Claims workbook)

(see *Security Claims Workbook* for requirement number crossref)