### PR TITLE
Architecture Review Updates

### DIFF
--- a/docs/source/Activities/Architecture_Review_Methodology.md
+++ b/docs/source/Activities/Architecture_Review_Methodology.md
@@ -53,3 +53,69 @@ The Architecture Review will identify the components of the system and how the s
 
 A {term}`BPMN` process model of the architecture review process
 :::
+
+**Tasks**
+
+**Perform Threat Modeling**
+
+*Threat modeling takes the provider submitted architectural
+documentation as input along with interview sessions with individuals
+that possess knowledge about the system and software architecture. The
+security control families provided by the application are enumerated
+using the threat modeling methodology.*
+
+Outputs:
+
+- SAMM Presentation
+- Security Service Listing
+- System Level Scores
+- Threat Model
+
+**Bill of Material Analysis**
+
+*Analyze the third party libraries used by the product, including
+licenses, maintainers, and known vulnerabilities.*
+
+Outputs:
+
+- Reliability Scores
+- Software BOM
+
+**Perform Software Architecture Analysis**
+
+*Analyze the software architecture using tools and interviews.*
+
+Inputs:  Software BOM
+
+Outputs:  Software Level Scores
+
+**Perform Depth Scoring**
+
+Outputs:  Depth Score
+
+**Build architectural model**
+
+*Create an architectural model containing the components, trust
+boundaries, and interfaces.*
+
+Inputs:
+
+- Reliability Scores
+- Security Service
+- Software BOM
+- Software Level Scores
+- System Level Scores
+
+Outputs:
+
+- Architecture Review Report
+- Point of Use Score
+
+**Generate Scoring Spreadsheets**
+
+Inputs:
+
+- Depth Score
+- Point of Use Score
+
+Outputs:  Consolidated Architecture Scores

--- a/docs/source/Activities/Architecture_Review_Methodology.md
+++ b/docs/source/Activities/Architecture_Review_Methodology.md
@@ -58,11 +58,11 @@ A {term}`BPMN` process model of the architecture review process
 
 **Perform Threat Modeling**
 
-*Threat modeling takes the provider submitted architectural
+Threat modeling takes the provider submitted architectural
 documentation as input along with interview sessions with individuals
 that possess knowledge about the system and software architecture. The
 security control families provided by the application are enumerated
-using the threat modeling methodology.*
+using the threat modeling methodology.
 
 Outputs:
 
@@ -73,8 +73,8 @@ Outputs:
 
 **Bill of Material Analysis**
 
-*Analyze the third party libraries used by the product, including
-licenses, maintainers, and known vulnerabilities.*
+Analyze the third party libraries used by the product, including
+licenses, maintainers, and known vulnerabilities.
 
 Outputs:
 
@@ -83,7 +83,7 @@ Outputs:
 
 **Perform Software Architecture Analysis**
 
-*Analyze the software architecture using tools and interviews.*
+Analyze the software architecture using tools and interviews.
 
 Inputs:  Software BOM
 
@@ -95,8 +95,8 @@ Outputs:  Depth Score
 
 **Build architectural model**
 
-*Create an architectural model containing the components, trust
-boundaries, and interfaces.*
+Create an architectural model containing the components, trust
+boundaries, and interfaces.
 
 Inputs:
 

--- a/docs/source/Security_Services_Architectural_Maturity_Index/SSAM_Rubric.md
+++ b/docs/source/Security_Services_Architectural_Maturity_Index/SSAM_Rubric.md
@@ -1,30 +1,30 @@
 
 # Rubric
 
-## Reliability
+## Reliability and Quality
 
 The Component (or the substantial logic thereof) is provided by a
 reputable party and actively maintained.
 
-  - 0 – Component is unvetted
+  - 0 – Written in-house with minimal documentation or third-party component that is uncommon and/or not actively supported
 
-  - 1 – Vetted component is used, but is not a current version
+  - 1 – Vetted component is used, but is not a current versionThird-party component is used, but may not be a current version or actively supported 
 
-  - 2 – Mature, vetted component with multiple active contributors
+  - 2 – Mature, vetted component with multiple active contributorsMature, third-party component with multiple active contributors; configured by secure best practices/guidelines
 
-  - 3 – Using a mature, vetted component, actively supported or approved
-    by a professional community/organization
+  - 3 – Using a mature, third-party component, actively supported by a professional community/organization, and is enforced by technical or procedural controls
 
 ## Manageability and Consistency
 
-The Component’s configuration is centrally managed by the provider and
-the configuration is under full change management with attribution.
+The Component is: Centrally managed by the provider, configurations are tuned with best practices, configurations are enforced, and the configuration is under full change management with attribution.
 
   - 0 – Component does not exhibit any of the criteria
 
-  - 1 – Component exhibits one criterion
+  - 1 – Component exhibits one or two criteria
 
-  - 2 – Component exhibits both criteria
+  - 2 – Component exhibits three of the criteria
+
+  - 3 - Component exhibits all four criteria
 
 ## Maintainability: Modularity
 
@@ -59,17 +59,15 @@ software component.
 
 ## Depth
 
-Components are complementary to provide a consistent, layered defense
-for the overall system. There should not be multiple versions or flavors
-of the security service component unless absolutely necessary.
+Component is segregated from other components and reusable inside other components. Components are complimentary to provide a consistent, layered defense for the overall system. There should are not be multiple versions or flavors variations of the security service component unless absolutely necessary.  
 
   - 0 – Components coverage is lacking and/or haphazardly applied
 
-  - 1 – Component coverage has gaps, is managed inconsistently
+  - 1 – Component coverage has gaps, is managed inconsistentlyComponent coverage has gaps, is managed inconsistently, and is not segregated
 
-  - 2 – Components coverage has minimal gaps, some layering
+  - 2 – Components coverage has minimal gaps, some layeringComponent coverage has minimal gaps, some layering and segregation, and part of a repeatable process
 
-  - 3 – Components are intentional, built into layers
+  - 3 – Components are intentional, built into layersComponents are intentional, built into layers, part of a repeatable/auditable process, and tested regularly
 
 # Rubric Configuration
 
@@ -79,7 +77,7 @@ Logging and Alerting Services, each would be scored separately across
 the measures below.
 
 Scoring is based on three measures, with maintainability broken down
-into modularity (for system level services) and analyzability (for
+into modularity (for system level services) and isolation (for
 software-only or composite services). Depth is scored once per security
 service type, at the aggregate level only.
 
@@ -89,4 +87,4 @@ provider
 | TYPE        | RELIABILITY | CONSISTENCY | MODULARITY      | ISOLATION     | EXAMPLE                      |
 | ----------- | ----------- | ----------- | --------------- | ------------- | ---------------------------- |
 | Transparent | x           | x           | x               |               | Firewall                     |
-| Composite   | x           | x           | x               | x             | Azure AD integrated with App |
+| Composite   | x           | x           | Service Only    | Software Only | Azure AD integrated with App |

--- a/docs/source/Security_Services_Architectural_Maturity_Index/SSAM_Rubric.md
+++ b/docs/source/Security_Services_Architectural_Maturity_Index/SSAM_Rubric.md
@@ -40,7 +40,7 @@ dedicated to providing its security service
 
   - 3 – separate unit of deployment (cloud service, or physically)
 
-## **Maintainability: Isolation** (Composite Services Only)
+## Maintainability: Isolation (Composite Services Only)
 
 Access to the security service component is mediated through a central
 software component.

--- a/docs/source/Security_Services_Architectural_Maturity_Index/SSAM_Rubric.md
+++ b/docs/source/Security_Services_Architectural_Maturity_Index/SSAM_Rubric.md
@@ -8,11 +8,11 @@ reputable party and actively maintained.
 
   - 0 – Written in-house with minimal documentation or third-party component that is uncommon and/or not actively supported
 
-  - 1 – Vetted component is used, but is not a current versionThird-party component is used, but may not be a current version or actively supported 
+  - 1 – Third-party component is used, but may not be a current version or actively supported 
 
-  - 2 – Mature, vetted component with multiple active contributorsMature, third-party component with multiple active contributors; configured by secure best practices/guidelines
+  - 2 – Mature, third-party component with multiple active contributors; configured by secure best practices/guidelines
 
-  - 3 – Using a mature, third-party component, actively supported by a professional community/organization, and is enforced by technical or procedural controls
+  - 3 – Using a mature, third-party component, that is actively supported by a professional community/organization, and is enforced by technical or procedural controls
 
 ## Manageability and Consistency
 
@@ -59,7 +59,7 @@ software component.
 
 ## Depth
 
-Component is segregated from other components and reusable inside other components. Components are complimentary to provide a consistent, layered defense for the overall system. There should are not be multiple versions or flavors variations of the security service component unless absolutely necessary.  
+Component is segregated from other components and reusable inside other components. Components are complimentary to provide a consistent, layered defense for the overall system. There should not be multiple versions or flavors variations of the security service component unless absolutely necessary.  
 
   - 0 – Components coverage is lacking and/or haphazardly applied
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,14 +9,6 @@ RABET-V Program
 
 .. toctree::
    :maxdepth: 2
-   :caption: Overview
-
-   Overview/Security_Control_Family
-   Overview/Maturity_Indexes
-
-   
-.. toctree::
-   :maxdepth: 2
    :caption: Activities
 
    Activities/README
@@ -29,6 +21,14 @@ RABET-V Program
    Activities/Product_Verification_Process
    Activities/Reporting_Process
 
+.. toctree::
+   :maxdepth: 2
+   :caption: Supporting Concepts
+
+   Overview/Security_Control_Family
+   Overview/Maturity_Indexes
+
+   
 .. toctree::
    :maxdepth: 2
    :caption: SSCM


### PR DESCRIPTION
- Adds back steps associated to process diagram from Signavio model
- Sync Rubric with internal document
- Renames "Overview" section to "Supporting Documents" (NB: containing directory is still `Overview`)